### PR TITLE
Add FastAPI inference service and switch Docker entrypoint to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ The Brats ML Predictor Web Application is a powerful and user-friendly tool desi
 
 # Technologies Used
 
-- Streamlit: An open-source Python library for building interactive web applications, particularly in the realm of data science and machine learning   
+- Streamlit: An open-source Python library for building interactive web applications, particularly in the realm of data science and machine learning
+- FastAPI: A high-performance Python web framework used to expose the ML inference as an API.
 - Machine Learning: Incorporates cutting-edge deep learning architectures trained on the BraTS dataset, ensuring high accuracy in tumor detection and classification.
 - Data Storage: Utilizes efficient data storage solutions for managing MRI images and prediction results.
 
@@ -26,13 +27,23 @@ To get started with the Brats ML Predictor Web Application, follow these steps:
         git clone https://github.com/jimsnns/brats_ml_predictor.git
         cd your-github-folder\brats_ml_predictor
 
-3. Install Dependencies:
+2. Install Dependencies:
 
+        cd app
         pip install -r requirements.txt
 
-4. Run the Application:
+3. Run the Application:
 
-        python homepage.py
+        uvicorn api:app --host 0.0.0.0 --port 8000
+
+4. Run a Prediction Request:
+
+        curl -X POST "http://localhost:8000/predict" \
+          -F "t2=@/path/to/t2.nii" \
+          -F "t1ce=@/path/to/t1ce.nii" \
+          -F "flair=@/path/to/flair.nii"
+
+    The response contains a Base64-encoded NumPy array (`prediction_npy_base64`) with the predicted segmentation mask.
 
 # Installation and Setup on Docker
 
@@ -45,12 +56,22 @@ To create and run a docker container and run the Brats ML Predictor Web Applicat
 
 2. Run the Application in Docker:
 
-        docker build -t brats_ml_predictor .
-        docker run -p 5000:5000 brats_ml_predictor
-   
-This setup will clone the repository, build the Docker image, and run the application in a Docker container, making it immediately ready for use.
+        docker build -t brats_ml_predictor app
+        docker run -p 8000:8000 brats_ml_predictor
 
-  # Contributing
+   After the container starts, call the `/predict` endpoint as shown above.
+
+# Model Optimization Ideas
+
+If you want to optimize the model further, consider the following:
+
+- Use mixed precision training and ensure the GPU supports Tensor Cores to reduce training time.
+- Add data augmentation (random flips, rotations, intensity shifts) to improve generalization.
+- Experiment with learning rate schedules (cosine decay, one-cycle policy) and class-weight tuning.
+- Use patch-based training and inference if GPU memory is a bottleneck.
+- Export the model with TensorRT or ONNX for faster inference in production.
+
+# Contributing
 
 We welcome contributions from the community! If you would like to contribute to this project, please follow these steps:
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -28,9 +28,9 @@ RUN useradd -m -u 1000 appuser && \
 
 USER appuser
 
-EXPOSE 8501
+EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl --fail http://localhost:8501/_stcore/health || exit 1
+    CMD curl --fail http://localhost:8000/health || exit 1
 
-ENTRYPOINT ["streamlit", "run", "homepage.py", "--server.port=8501", "--server.address=0.0.0.0"]
+ENTRYPOINT ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,108 @@
+import base64
+from functools import lru_cache
+from io import BytesIO
+
+import nibabel as nib
+import numpy as np
+import segmentation_models_3D as sm
+import tensorflow as tf
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from sklearn.preprocessing import MinMaxScaler
+from tensorflow.keras import backend as K
+from tensorflow.keras.models import load_model
+
+app = FastAPI(title="BraTS ML Predictor API", version="1.0.0")
+
+CLASS_NAMES = [
+    "Not Tumor",
+    "Non-Enhancing Tumor class 1",
+    "Edema class 2",
+    "Enhancing Tumor class 3",
+]
+
+
+def precision(y_true, y_pred):
+    true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
+    predicted_positives = K.sum(K.round(K.clip(y_pred, 0, 1)))
+    return true_positives / (predicted_positives + K.epsilon())
+
+
+@lru_cache(maxsize=1)
+def get_model():
+    wt0, wt1, wt2, wt3 = 0.26, 22.53, 22.53, 26.21
+    dice_loss = sm.losses.DiceLoss(class_weights=np.array([wt0, wt1, wt2, wt3]))
+    focal_loss = sm.losses.CategoricalFocalLoss()
+    f_score = sm.metrics.FScore()
+    recall = tf.keras.metrics.Recall()
+    iou = sm.metrics.IOUScore()
+
+    return load_model(
+        "training_3d_200epoch_final_default.hdf5",
+        custom_objects={
+            "iou_score": iou,
+            "dice_loss": dice_loss,
+            "focal_loss": focal_loss,
+            "f1-score": f_score,
+            "precision": precision,
+            "recall": recall,
+        },
+    )
+
+
+def _load_nifti_from_upload(uploaded_file: UploadFile) -> np.ndarray:
+    file_content = uploaded_file.file.read()
+    if not file_content:
+        raise HTTPException(status_code=400, detail=f"{uploaded_file.filename} is empty.")
+    file_io = BytesIO(file_content)
+    fileholder = nib.FileHolder(fileobj=file_io)
+    img = nib.Nifti1Image.from_file_map({"header": fileholder, "image": fileholder})
+    return img.get_fdata()
+
+
+def _load_and_scale(uploaded_file: UploadFile, scaler: MinMaxScaler) -> np.ndarray:
+    img_data = _load_nifti_from_upload(uploaded_file)
+    return scaler.fit_transform(img_data.reshape(-1, img_data.shape[-1])).reshape(img_data.shape)
+
+
+def _prepare_volume(t2: np.ndarray, t1ce: np.ndarray, flair: np.ndarray) -> np.ndarray:
+    combined_data = np.stack([t2, t1ce, flair], axis=3)
+    combined_data = combined_data[56:184, 56:184, 13:141]
+    return np.expand_dims(combined_data, axis=0)
+
+
+@app.get("/health")
+def health_check():
+    return {"status": "ok"}
+
+
+@app.post("/predict")
+async def predict(
+    t2: UploadFile = File(...),
+    t1ce: UploadFile = File(...),
+    flair: UploadFile = File(...),
+):
+    for uploaded in (t2, t1ce, flair):
+        if not uploaded.filename.endswith(".nii"):
+            raise HTTPException(status_code=400, detail=f"{uploaded.filename} must be a .nii file.")
+
+    scaler = MinMaxScaler()
+    t2_data = _load_and_scale(t2, scaler)
+    t1ce_data = _load_and_scale(t1ce, scaler)
+    flair_data = _load_and_scale(flair, scaler)
+
+    model_input = _prepare_volume(t2_data, t1ce_data, flair_data)
+    model = get_model()
+
+    prediction = model.predict(model_input)
+    prediction_argmax = np.argmax(prediction, axis=4)[0, :, :, :].astype(np.uint8)
+
+    buffer = BytesIO()
+    np.save(buffer, prediction_argmax)
+    buffer.seek(0)
+    encoded = base64.b64encode(buffer.read()).decode("utf-8")
+
+    return {
+        "classes": CLASS_NAMES,
+        "prediction_shape": prediction_argmax.shape,
+        "prediction_npy_base64": encoded,
+    }

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,9 +1,12 @@
+fastapi==0.115.11
 keras==3.12.0
 matplotlib==3.9.4
 nibabel==5.2.1
 numpy==1.26.4
+python-multipart==0.0.9
 scikit_learn==1.7.2
 segmentation_models_3D==1.0.5
 streamlit==1.51.0
 tensorflow==2.15.1
 protobuf==4.25.8
+uvicorn==0.34.0


### PR DESCRIPTION
### Motivation
- Provide a programmatic inference endpoint so the model can be called from an API instead of only via the Streamlit notebook/webapp.
- Support lightweight, production-friendly serving with `uvicorn` and container healthchecks.
- Document API usage and outline simple model optimization ideas for future improvements.

### Description
- Add a FastAPI app at `app/api.py` exposing `GET /health` and `POST /predict` that load the 3D model with required `custom_objects`, preprocess uploaded NIfTI files, run inference, and return a Base64-encoded `.npy` prediction along with class names and shape.
- Update `app/Dockerfile` to expose port `8000`, run the API with `uvicorn` as the container entrypoint, and point the healthcheck at `/health`.
- Update `app/requirements.txt` to include `fastapi`, `uvicorn`, and `python-multipart` required for the API and multipart uploads.
- Update top-level `README.md` to document running the API locally and in Docker and to add a short section with model optimization suggestions (mixed precision, augmentations, LR schedules, patch-based training, ONNX/TensorRT export).

### Testing
- No automated tests were run for this change (none requested during the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885e9e26e483258851e7581c2ae968)